### PR TITLE
Feat/testing

### DIFF
--- a/app/Http/Controllers/Api/GameController.php
+++ b/app/Http/Controllers/Api/GameController.php
@@ -23,6 +23,13 @@ class GameController extends Controller
                 'error' => 'User not found.'
             ], 404);
         }
+
+        if($request->user()->id !== $user->id) {
+            return response()->json([
+                'error' => 'Hey, you are not allowed to play here! :('
+            
+            ], 403);
+        }
             
         if ($user->role->name !== 'player' && !$request->user()->tokenCan('dice_roll')) {
           
@@ -84,6 +91,12 @@ class GameController extends Controller
                     'error' => 'User not found.'
                 ], 404);
             }
+            if($request->user()->id !== $user->id) {
+                return response()->json([
+                    'error' => 'Hey, you are not allowed to play here! :('
+                
+                ], 403);
+            }
     
             if ($user->role->name !== 'player' && !$request->user()->tokenCan('list_rolls')) {
               
@@ -135,6 +148,13 @@ class GameController extends Controller
             return response()->json([
                 'error' => 'User not found.'
             ], 404);
+        }
+
+        if($request->user()->id !== $user->id) {
+            return response()->json([
+                'error' => 'Hey, you are not allowed to delete this! :('
+            
+            ], 403);
         }
 
         if ($user->role->name !== 'player' && !$request->user()->tokenCan('delete_list')) {

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -165,13 +165,17 @@ class UserController extends Controller
                 'error' => 'User not found.'
             ], 404);
         }
+
+        if($request->user()->id !== $user->id) {
+            return response()->json([
+                'error' => 'Hey, you are not allowed to update this! :('
+            ], 403);
+        }
             
         if ($user->role->name !== 'player' && !$request->user()->tokenCan('update_nick')) {
           
             return response()->json([
-                
-                'error' => 'Hey, you are not allowed to play! :('
-            
+                'error' => 'Hey, you are not allowed to update this! :('
             ], 403);
         }
 

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -160,10 +160,19 @@ class UserController extends Controller
 
         $user = User::find($id);
 
-        if(!$user && $user->role->name != 'player' || $user->role->name != 'admin'){
+        if (!$user) {
             return response()->json([
-                'message' => 'Sorry, you do not have permission to update this :(',
+                'error' => 'User not found.'
             ], 404);
+        }
+            
+        if ($user->role->name !== 'player' && !$request->user()->tokenCan('update_nick')) {
+          
+            return response()->json([
+                
+                'error' => 'Hey, you are not allowed to play! :('
+            
+            ], 403);
         }
 
        $rules = [
@@ -187,16 +196,18 @@ class UserController extends Controller
 
         $new_nickname = $request->input('nickname');
         
+        if(empty($new_nickname)){
+            $new_nickname = 'Anonymous';
+        }
+        
         if ($new_nickname !== $user->nickname){
-                
-            $user->nickname = $new_nickname ?? 'Anonymous';
-            
+            $user->nickname = $new_nickname;
             $user->update();
 
             return response()->json([
                 'message' => 'Nickname successfully updated!',
             ], 200);
-    }
+        }
 
         return response()->json([
             'message' => 'Same nickname. No changes were made :(',

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -216,8 +216,13 @@ class UserController extends Controller
     
     }
 
-    public function logout() {
-        
+    public function logout(Request $request) {
+
+        if($request->user()->role->name !== 'player' && !$request->user()->tokenCan('logout')) {
+            return response()->json([
+                'error' => 'Hey, you are not allowed! :('
+            ], 403);
+        }
             /** @var \App\Models\User $user **/
           $user = Auth::user();
   
@@ -254,9 +259,10 @@ class UserController extends Controller
             $players_list[] = $player;
         };  
 
-        return $players_list;
+        return response()->json([
+            $players_list,
 
-       
+        ]);
     }
 
     public function ranking_players(Request $request){

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -13,16 +13,18 @@ use Illuminate\Support\Facades\Validator;
 
 
 
+
+
 class UserController extends Controller
 {
 
-    //register
+//register
 
     public function register(Request $request){
 
 
         $user_rules = [
-            'nickname' => 'nullable|alpha_num:ascii|unique:users|max:20',
+            'nickname' => 'nullable|alpha_num:ascii|unique:users',
             'email' => 'required|string|unique:users,email',
             'password' => 'required|string|min:8',
         ];
@@ -30,7 +32,6 @@ class UserController extends Controller
         $error_msg = [
             'nickname.alpha_num' => 'This is not a correct nickname. Use letters and numbers only.',
             'nickname.unique' => 'This nickname is already in use. Write a new nickname.',
-            'nickname.max' => 'This nickname is too long. Only 20 characters allowed.',
             'email.email' => 'The email field must contain a valid email.',
             'email.required' => 'The email field is required.',
             'email.unique' => 'This email is already in use.',
@@ -50,13 +51,20 @@ class UserController extends Controller
     
             ], 422);
         }
+        
+        //Verificamos que el email no esté duplicado en la bbdd
+       /* if (User::where('email', $request->input('email'))->exists()) {
+            return response()->json([
+                'message' => 'This email is already in use',
+            ], 422);
+        } */
 
 
        // Si el nickname queda vacío, asignamos el valor anonymous con el operador de fusión null
 
         $nickname = $request->input('nickname') ?? 'Anonymous';
 
-        // Si todo es correcto -> creamos un nuevo ususario y le asignamos el rol player
+        // Si todo es correcto -> creamos un nuevo ususario
         $user = User::create([
 
             'nickname' => $nickname,
@@ -64,6 +72,12 @@ class UserController extends Controller
             'password' => bcrypt($request->input('password')),
             'role_id' => Role::where('name', 'player')->first()->id,
         ]);
+
+        //Le añadimos el rol player en su tabla
+        //$user->roles()->attach(Role::where('name', 'player')->first());
+        //$user->('player');
+        //$role = Role::where('name', 'player')->first();
+       // $user->role()->attach($role->id);
 
         if ($user) {
             return response()->json([
@@ -146,25 +160,18 @@ class UserController extends Controller
 
         $user = User::find($id);
 
-        if (!$user) {
-            return response()->json([
-                'error' => 'User not found.'
-            ], 404);
-        }
-
-        if( ($user->role->name !== 'player' || $user->role->name !== 'admin') && !$user->tokenCan('update_nick')){
+        if(!$user && $user->role->name != 'player' || $user->role->name != 'admin'){
             return response()->json([
                 'message' => 'Sorry, you do not have permission to update this :(',
             ], 404);
         }
 
        $rules = [
-            'nickname' => 'nullable|alpha_num:ascii|max:20|unique:users,nickname,'.$id,
+            'nickname' => 'nullable|alpha_num:ascii|unique:users,nickname,'.$id,
             ];
 
        $error_msg = [
             'nickname.alpha_num' => 'This is not a correct nickname. Use letters and numbers only.',
-            'nickname.max' => 'This nickname is too long. Only 20 characters allowed.',
             'nickname.unique' => 'This nickname is already taken. Please write a new nickname.',
        ];
 
@@ -216,7 +223,7 @@ class UserController extends Controller
 
     public function list_players(Request $request){
 
-        if($request->user()->role->name !== 'admin' && !$request->user()->tokenCan('list_all_players')) {
+        if($request->user()->role->name != 'admin' && !$request->user()->tokenCan('list_all_players')) {
             return response()->json([
                 'error' => 'Hey, you are not allowed! :('
             ], 403);
@@ -243,7 +250,7 @@ class UserController extends Controller
 
     public function ranking_players(Request $request){
 
-        if($request->user()->role->name !== 'admin' && !$request->user()->tokenCan('list_ranking')) {
+        if($request->user()->role->name != 'admin' && !$request->user()->tokenCan('list_ranking')) {
             return response()->json([
                 'error' => 'Hey, you are not allowed! :('
             ], 403);
@@ -285,7 +292,7 @@ class UserController extends Controller
 
     public function ranking_winner(Request $request){
 
-        if($request->user()->role->name !== 'admin' && !$request->user()->tokenCan('list_winner')) {
+        if($request->user()->role->name != 'admin' && !$request->user()->tokenCan('list_winner')) {
             return response()->json([
                 'error' => 'Hey, you are not allowed! :('
             ], 403);
@@ -307,7 +314,7 @@ class UserController extends Controller
 
     public function ranking_loser(Request $request){
 
-        if($request->user()->role->name !== 'admin' && !$request->user()->tokenCan('list_loser')) {
+        if($request->user()->role->name != 'admin' && !$request->user()->tokenCan('list_loser')) {
             return response()->json([
                 'error' => 'Hey, you are not allowed! :('
             ], 403);

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -28,7 +28,7 @@ class AuthServiceProvider extends ServiceProvider
         
         Passport::tokensCan([
 
-            'admin' => 'update_nick, list_all_players, list_ranking, list_winner, list_loser',
+            'admin' => 'list_all_players, list_ranking, list_winner, list_loser',
             'player' => 'update_nick, dice_roll, list_rolls, delete_list'
             
         ]);

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -29,7 +29,7 @@ class AuthServiceProvider extends ServiceProvider
         Passport::tokensCan([
 
             'admin' => 'list_all_players, list_ranking, list_winner, list_loser',
-            'player' => 'update_nick, dice_roll, list_rolls, delete_list'
+            'player' => 'update_nick, dice_roll, list_rolls, delete_list, logout',
             
         ]);
 

--- a/database/factories/GameFactory.php
+++ b/database/factories/GameFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Game>
+ */
+class GameFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,7 +24,7 @@ Route::post('register', [UserController::class, 'register'])->name('register');
 Route::post('login', [UserController::class, 'login'])->name('login');
 
 //register
-Route::middleware('auth:api, scope:admin,player')->group(function () { //, scope:admin,player
+Route::middleware('auth:api, scope:player')->group(function () { //, scope:admin,player
 
 
        Route::get('user', [UserController::class, 'user'])->name('user');

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -12,7 +12,7 @@ class ExampleTest extends TestCase
      */
     public function test_the_application_returns_a_successful_response(): void
     {
-        $response = $this->get('/');
+        $response = $this->get('register');
 
         $response->assertStatus(200);
     }

--- a/tests/Feature/GameControllerTest.php
+++ b/tests/Feature/GameControllerTest.php
@@ -7,7 +7,7 @@ use App\Models\User;
 use App\Models\Role;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 //use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
+
 use Tests\TestCase;
 
 class GameControllerTest extends TestCase
@@ -15,10 +15,169 @@ class GameControllerTest extends TestCase
     use DatabaseTransactions;
 
     //Dice Roll
-    public function test_example(): void
+    public function test_games_player_can_roll_dice(): void
     {
-        $response = $this->get('/');
+        $user = User::factory()->create([
+            'nickname' => 'playerNickname',
+            'email' => 'player@example.com',
+            'password' => '123456789',
+            'role_id' => Role::where('name', 'player')->first()->id,
+        ]);
+    
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $user->createToken('player_token', ['player'])->accessToken,
+        ])->postJson('/api/players/'.$user->id.'/games/');
 
-        $response->assertStatus(200);
+        //dump($response->content());
+    
+        $response->assertStatus(200)
+        ->assertJsonStructure([
+            'message',
+            'dice1',
+            'dice2',
+            'result',
+            'rate'
+        ]);
+
     }
+    public function test_games_player1_cannot_play_in_roll_dice_of_player2(): void
+    {
+        $user1 = User::factory()->create([
+            'nickname' => 'playerNickname',
+            'email' => 'player@example.com',
+            'password' => '123456789',
+            'role_id' => Role::where('name', 'player')->first()->id,
+        ]);
+        $user2 = User::factory()->create([
+            'nickname' => 'player2Nickname',
+            'email' => 'player2@example.com',
+            'password' => '123456789',
+            'role_id' => Role::where('name', 'player')->first()->id,
+        ]);
+    //'.$user->id.'/games/'
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $user1->createToken('player_token', ['player'])->accessToken,
+        ])->postJson('/api/players/'.$user2->id.'/games/');
+
+        //dump($response->content());
+    
+        $response->assertStatus(403)
+                ->assertJson(['error' => 'Hey, you are not allowed to play here! :(']);
+    }
+
+    //show players games list
+    public function test_games_player_can_see_its_rolls(): void
+    {
+        $player = User::factory()->create([
+            'nickname' => 'playerNickname',
+            'email' => 'player@example.com',
+            'password' => '123456789',
+            'role_id' => Role::where('name', 'player')->first()->id,
+        ]);
+
+        $game1 = Game::create([
+            'dice1' => '5',
+            'dice2' => '5',
+            'result' => '11',
+            'user_id' =>$player->id
+        ]);
+    
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $player->createToken('player_token', ['player'])->accessToken,
+        ])->getJson('/api/players/'.$player->id.'/games');
+
+        //dump($response->content());
+    
+        $response->assertStatus(200);
+        $this->assertDatabaseHas(
+            'games',
+            [
+                'dice1' =>$game1->dice1,
+                'dice2' =>$game1->dice2,
+                'result' =>$game1->result,
+                'user_id' =>$player->id,
+            ]);
+    }
+
+    public function test_games_admin_cannot_see_players_rolls_list(): void
+    {
+        $user1 = User::factory()->create([
+            'nickname' => 'adminNickname',
+            'email' => 'admin@example.com',
+            'password' => '123456789',
+            'role_id' => Role::where('name', 'admin')->first()->id,
+        ]);
+        
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $user1->createToken('admin_token', ['admin'])->accessToken,
+        ])->getJson('/api/players/'.$user1->id.'/games');
+
+        //dump($response->content());
+    
+        $response->assertStatus(403);
+    }
+
+    //delete rolls
+    public function test_games_delete_rolls_works(): void
+    {
+        $user1 = User::factory()->create([
+            'nickname' => 'playerNickname',
+            'email' => 'player@example.com',
+            'password' => '123456789',
+            'role_id' => Role::where('name', 'player')->first()->id,
+        ]);
+        $game1 = Game::create([
+            'dice1' => '5',
+            'dice2' => '5',
+            'result' => '12',
+            'user_id' =>$user1->id
+        ]);
+    
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $user1->createToken('player_token', ['player'])->accessToken,
+        ])->deleteJson('/api/players/'.$user1->id.'/games');
+
+        //dump($response->content());
+    
+        $response->assertStatus(200);
+        $this->assertDatabaseMissing(
+            'games',
+            [
+                'dice1' =>$game1->dice1,
+                'dice2' =>$game1->dice2,
+                'result' =>$game1->result,
+                'user_id' =>$user1->id,
+            ]);
+            
+        $response->assertJson(['message' => 'Your records were successfully deleted.']);
+        
+    }
+
+    public function test_games_admin_cannot_delete_players_rolls(): void
+    {
+        $admin = User::factory()->create([
+            'nickname' => 'adminNickname',
+            'email' => 'admin@example.com',
+            'password' => '123456789',
+            'role_id' => Role::where('name', 'admin')->first()->id,
+        ]);
+        $player = User::factory()->create([
+            'nickname' => 'player2Nickname',
+            'email' => 'player2@example.com',
+            'password' => '123456789',
+            'role_id' => Role::where('name', 'player')->first()->id,
+        ]);
+    
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $admin->createToken('player_token', ['admin'])->accessToken,
+        ])->deleteJson('/api/players/'.$player->id.'/games');
+
+        //dump($response->content());
+    
+        $response->assertStatus(403)
+                ->assertJson(['error' => 'Hey, you are not allowed to delete this! :(']);
+    }
+
+
+
 }

--- a/tests/Feature/GameControllerTest.php
+++ b/tests/Feature/GameControllerTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Feature;
+
+Use App\Models\Game;
+use App\Models\User;
+use App\Models\Role;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+//use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class GameControllerTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    //Dice Roll
+    public function test_example(): void
+    {
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+    }
+}

--- a/tests/Feature/UserControllerActionsTest.php
+++ b/tests/Feature/UserControllerActionsTest.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace Tests\Feature;
+
+Use App\Models\Game;
+use App\Models\User;
+use App\Models\Role;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+//use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class UserControllerActionsTest extends TestCase
+{
+    use DatabaseTransactions;
+    
+    //List players
+    public function test_admin_can_list_players(): void
+    {
+        $user = User::factory()->create([
+            'nickname' => 'AdminNickname',
+            'email' => 'admin@example.com',
+            'password' => '123456789',
+            'role_id' => Role::where('name', 'admin')->first()->id,
+        ]);
+
+        $player1 = User::factory()->create([
+            'role_id' => Role::where('name', 'player')->first(),
+            'nickname' => 'Player1',
+            'email' => 'player1@example.com',
+            'password' => '123456789',
+        ]);
+    
+        $player2 = User::factory()->create([
+            'role_id' => Role::where('name', 'player')->first(),
+            'nickname' => 'Player2',
+            'email' => 'player@example.com',
+            'password' => '123456789',
+        ]);
+
+        $game1 = Game::factory()->create([
+            'dice1' => '6',
+            'dice2' => '5',
+            'result' => '11',
+            'user_id' =>$player1->id
+        ]);
+        $game2 = Game::factory()->create([
+            'dice1' => '3',
+            'dice2' => '4',
+            'result' => '7',
+            'user_id' =>$player2->id
+        ]);
+    
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $user->createToken('admin_token', ['admin'])->accessToken,
+        ])->getJson('/api/players');
+
+        //dump($response->content());
+    
+        $response->assertStatus(200)
+        ->assertJsonIsArray();
+    }
+
+    public function test_player_cannot_list_players(): void
+    {
+        $user = User::factory()->create([
+            'nickname' => 'AdminNickname',
+            'email' => 'admin@example.com',
+            'password' => '123456789',
+            'role_id' => Role::where('name', 'player')->first()->id,
+        ]);
+    
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $user->createToken('player_token', ['player'])->accessToken,
+        ])->getJson('/api/players');
+
+        //dump($response->content());
+    
+        $response->assertForbidden();
+        
+    }
+
+    //ranking players
+    public function test_admin_can_list_ranking(): void
+    {
+        $user = User::factory()->create([
+            'nickname' => 'AdminNickname',
+            'email' => 'admin@example.com',
+            'password' => '123456789',
+            'role_id' => Role::where('name', 'admin')->first()->id,
+        ]);
+    
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $user->createToken('admin_token', ['admin'])->accessToken,
+        ])->getJson('/api/players/ranking');
+
+        dump($response->content());
+    
+        //$response->assertJson([
+    
+        $response->assertStatus(200);
+
+        $response->assertJsonPath('0', 'The average of all players is 16.67 %');
+        $response->assertJsonPath('1.0.Position', 1);
+        $response->assertJsonPath('1.0.nickname', 'Elisia');
+        $response->assertJsonPath('1.0.rate', 'The success rate is 20.00 % ');
+        $response->assertJsonPath('1.1.Position', 2);
+        $response->assertJsonPath('1.1.nickname', 'Mialomi');
+        $response->assertJsonPath('1.1.rate', 'The success rate is 14.29 % ');
+        }
+
+        public function test_player_cannot_ranking_players(): void
+        {
+            $user = User::factory()->create([
+                'nickname' => 'AdminNickname',
+                'email' => 'admin@example.com',
+                'password' => '123456789',
+                'role_id' => Role::where('name', 'player')->first()->id,
+            ]);
+        
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $user->createToken('player_token', ['player'])->accessToken,
+            ])->getJson('/api/players/ranking');
+    
+            //dump($response->content());
+        
+            $response->assertForbidden();
+            
+        }
+    
+        //ranking winner
+        public function test_admin_can_see_winner(): void
+        {
+            $user = User::factory()->create([
+                'nickname' => 'AdminNickname',
+                'email' => 'admin@example.com',
+                'password' => '123456789',
+                'role_id' => Role::where('name', 'admin')->first()->id,
+            ]);
+        
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $user->createToken('admin_token', ['admin'])->accessToken,
+            ])->getJson('/api/players/ranking/winner');
+    
+            //dump($response->content());
+        
+            $response->assertStatus(200)
+                    ->assertJsonIsArray();
+            
+        }
+
+        public function test_admin_cannot_see_winner_with_role_player_and_token_admin(): void
+        {
+            $user = User::factory()->create([
+                'nickname' => 'AdminNickname',
+                'email' => 'admin@example.com',
+                'password' => '123456789',
+                'role_id' => Role::where('name', 'player')->first()->id,
+            ]);
+        
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $user->createToken('admin_token', ['admin'])->accessToken,
+            ])->getJson('/api/players/ranking/winner');
+    
+            //dump($response->content());
+        
+            $response->assertStatus(403);
+                    
+        }
+    
+    //ranking looser
+    public function test_admin_can_see_one_loser(): void
+        {
+            $user = User::factory()->create([
+                'nickname' => 'AdminNickname',
+                'email' => 'admin@example.com',
+                'password' => '123456789',
+                'role_id' => Role::where('name', 'admin')->first()->id,
+            ]);
+        
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $user->createToken('admin_token', ['admin'])->accessToken,
+            ])->getJson('/api/players/ranking/loser');
+    
+            //dump($response->content());
+        
+            $response->assertStatus(200)
+                    ->assertJsonIsArray()
+                    ->assertJsonCount('1');
+            
+        }
+        public function test_player_cannot_see_looser_list(): void
+        {
+            $user = User::factory()->create([
+                'nickname' => 'PlayerNickname',
+                'email' => 'player@example.com',
+                'password' => '123456789',
+                'role_id' => Role::where('name', 'player')->first()->id,
+            ]);
+        
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $user->createToken('player_token', ['player'])->accessToken,
+            ])->getJson('/api/players/ranking/loser');
+    
+            dump($response->content());
+        
+            $response->assertStatus(403);
+                    
+        }
+    
+
+}

--- a/tests/Feature/UserControllerActionsTest.php
+++ b/tests/Feature/UserControllerActionsTest.php
@@ -7,7 +7,7 @@ use App\Models\User;
 use App\Models\Role;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 //use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
+
 use Tests\TestCase;
 
 class UserControllerActionsTest extends TestCase
@@ -25,17 +25,17 @@ class UserControllerActionsTest extends TestCase
         ]);
 
         $player1 = User::factory()->create([
-            'role_id' => Role::where('name', 'player')->first(),
             'nickname' => 'Player1',
             'email' => 'player1@example.com',
             'password' => '123456789',
+            'role_id' => Role::where('name', 'player')->first(),
         ]);
     
         $player2 = User::factory()->create([
-            'role_id' => Role::where('name', 'player')->first(),
             'nickname' => 'Player2',
             'email' => 'player@example.com',
             'password' => '123456789',
+            'role_id' => Role::where('name', 'player')->first(),
         ]);
 
         $game1 = Game::factory()->create([
@@ -64,8 +64,8 @@ class UserControllerActionsTest extends TestCase
     public function test_player_cannot_list_players(): void
     {
         $user = User::factory()->create([
-            'nickname' => 'AdminNickname',
-            'email' => 'admin@example.com',
+            'nickname' => 'PlayerNickname',
+            'email' => 'player@example.com',
             'password' => '123456789',
             'role_id' => Role::where('name', 'player')->first()->id,
         ]);
@@ -94,9 +94,7 @@ class UserControllerActionsTest extends TestCase
             'Authorization' => 'Bearer ' . $user->createToken('admin_token', ['admin'])->accessToken,
         ])->getJson('/api/players/ranking');
 
-        dump($response->content());
-    
-        //$response->assertJson([
+        //dump($response->content());
     
         $response->assertStatus(200);
 
@@ -112,8 +110,8 @@ class UserControllerActionsTest extends TestCase
         public function test_player_cannot_ranking_players(): void
         {
             $user = User::factory()->create([
-                'nickname' => 'AdminNickname',
-                'email' => 'admin@example.com',
+                'nickname' => 'playerNickname',
+                'email' => 'player@example.com',
                 'password' => '123456789',
                 'role_id' => Role::where('name', 'player')->first()->id,
             ]);
@@ -189,7 +187,7 @@ class UserControllerActionsTest extends TestCase
                     ->assertJsonCount('1');
             
         }
-        public function test_player_cannot_see_looser_list(): void
+        public function test_player_cannot_see_loser_list(): void
         {
             $user = User::factory()->create([
                 'nickname' => 'PlayerNickname',
@@ -202,7 +200,7 @@ class UserControllerActionsTest extends TestCase
                 'Authorization' => 'Bearer ' . $user->createToken('player_token', ['player'])->accessToken,
             ])->getJson('/api/players/ranking/loser');
     
-            dump($response->content());
+            //dump($response->content());
         
             $response->assertStatus(403);
                     

--- a/tests/Feature/UserControllerTest.php
+++ b/tests/Feature/UserControllerTest.php
@@ -6,16 +6,12 @@ Use App\Models\Game;
 use App\Models\User;
 use App\Models\Role;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
-use Laravel\Passport\Passport;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class UserControllerTest extends TestCase
 { 
     use DatabaseTransactions;
-    /**
-     * A basic feature test example.
-     */
+    
     public function test_register_is_correct(): void
     {
         $response = $this->postJson('/api/register',[
@@ -51,7 +47,6 @@ class UserControllerTest extends TestCase
         ]);    
 
         $response->assertStatus(201);
-
     }
 
     public function test_register_data_is_saved(): void
@@ -67,6 +62,7 @@ class UserControllerTest extends TestCase
         $this->assertDatabaseMissing('users', [
             'email' => 'test@example.com' ]);
     }
+
     public function test_register_email_already_exist(): void
     {
         $response = $this->post('/api/register',[
@@ -155,7 +151,6 @@ class UserControllerTest extends TestCase
             'nickname' => $newNickname,
         ]);
         
-
     }
 
     public function test_user_admin_cannot_update_nickname(): void
@@ -180,7 +175,7 @@ class UserControllerTest extends TestCase
     
         $response->assertStatus(403)
             ->assertJson([
-                'error' => 'Hey, you are not allowed to play! :(',
+                'error' => 'Hey, you are not allowed to update this! :(',
             ]);
         
     }
@@ -210,7 +205,8 @@ class UserControllerTest extends TestCase
                 'message' => 'Nickname successfully updated!',
             ]);
     
-        $this->assertDatabaseHas('users', [
+        $this->assertDatabaseHas
+        ('users', [
             'id' => $user->id,
             'nickname' => 'Anonymous',
         ]);
@@ -220,23 +216,23 @@ class UserControllerTest extends TestCase
     //Logout
     public function test_logout_is_correct(): void
     {
-        
-            $user = User::factory()->create([
-                'nickname' => 'OldNickname',
-                'email' => 'old@example.com',
-                'password' => '123456789',
-                'role_id' => Role::where('name', 'player')->first(),
-            ]);
-            $response = $this->withHeaders([
-                'Authorization' => 'Bearer ' . $user->createToken('player_token', ['player'])->accessToken,
+        $user = User::factory()->create([
+            'nickname' => 'userickname',
+            'email' => 'user@example.com',
+            'password' => '123456789',
+            'role_id' => Role::where('name', 'player')->first(),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $user->createToken('player_token', ['player'])->accessToken,
             ])->getJson('/api/logout');
 
-            dump($response->content());
+        //dump($response->content());
 
-            $response->assertStatus(200)
-            ->assertJson([
-                'message' => 'Successfully logged out. See you soon!'
-            ]);
+        $response->assertStatus(200)
+                ->assertJson([
+                    'message' => 'Successfully logged out. See you soon!'
+                ]);
         
     }
 

--- a/tests/Feature/UserControllerTest.php
+++ b/tests/Feature/UserControllerTest.php
@@ -120,8 +120,111 @@ class UserControllerTest extends TestCase
         ]);
 
         $response->assertStatus(200);
-        $this->assertDatabaseHas('users', [
+            $this->assertDatabaseHas('users', [
             'role_id' => '2' ]);
         
     }
+    //update 
+    public function test_user_can_update_nickname(): void
+    
+    {
+        $user = User::factory()->create([
+            'nickname' => 'OldNickname',
+            'email' => 'old@example.com',
+            'password' => '123456789',
+            'role_id' => Role::where('name', 'player')->first()->id,
+        ]);
+    
+        $newNickname = 'NewNickname';
+    
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $user->createToken('player_token', ['player'])->accessToken,
+        ])->putJson('/api/user/'.$user->id, [
+            'nickname' => $newNickname,
+        ]);
+
+        dump($response->content());
+    
+        $response->assertStatus(200)
+            ->assertJson([
+                'message' => 'Nickname successfully updated!',
+            ]);
+    
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+            'nickname' => $newNickname,
+        ]);
+        
+
+    }
+
+    public function test_user_admin_cannot_update_nickname(): void
+    
+    {
+        $user = User::factory()->create([
+            'nickname' => 'OldNickname',
+            'email' => 'old@example.com',
+            'password' => '123456789',
+            'role_id' => Role::where('name', 'admin')->first()->id,
+        ]);
+    
+        $newNickname = 'NewNickname';
+    
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $user->createToken('admin_token', ['admin'])->accessToken,
+        ])->putJson('/api/user/'.$user->id, [
+            'nickname' => $newNickname,
+        ]);
+
+        dump($response->content());
+    
+        $response->assertStatus(403)
+            ->assertJson([
+                'error' => 'Hey, you are not allowed to play! :(',
+            ]);
+        
+    }
+
+    public function test_user_player_can_update_with_empty_nickname_(): void
+    
+    {
+        $user = User::factory()->create([
+            'nickname' => 'OldNickname',
+            'email' => 'old@example.com',
+            'password' => '123456789',
+            'role_id' => Role::where('name', 'player')->first()->id,
+        ]);
+    
+        $newNickname = '';
+    
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $user->createToken('player_token', ['player'])->accessToken,
+        ])->putJson('/api/user/'.$user->id, [
+            'nickname' => $newNickname,
+        ]);
+
+        dump($response->content());
+    
+        $response->assertStatus(200)
+            ->assertJson([
+                'message' => 'Nickname successfully updated!',
+            ]);
+    
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+            'nickname' => 'Anonymous',
+        ]);
+        
+
+    }
+
+
+
+
+
+
+
+
+
+
 }

--- a/tests/Feature/UserControllerTest.php
+++ b/tests/Feature/UserControllerTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Feature;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Laravel\Passport\Passport;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class UserControllerTest extends TestCase
+{ 
+    use DatabaseTransactions;
+    /**
+     * A basic feature test example.
+     */
+    public function test_register_is_correct(): void
+    {
+        $response = $this->postJson('/api/register',[
+            'nickname' => 'Testnickname',
+            'email' => 'test@example.com',
+            'password' => 'testing123',
+
+        ]);    
+
+        $response->assertStatus(201);
+    }
+}

--- a/tests/Feature/UserControllerTest.php
+++ b/tests/Feature/UserControllerTest.php
@@ -143,7 +143,7 @@ class UserControllerTest extends TestCase
             'nickname' => $newNickname,
         ]);
 
-        dump($response->content());
+        //dump($response->content());
     
         $response->assertStatus(200)
             ->assertJson([
@@ -176,7 +176,7 @@ class UserControllerTest extends TestCase
             'nickname' => $newNickname,
         ]);
 
-        dump($response->content());
+        //dump($response->content());
     
         $response->assertStatus(403)
             ->assertJson([
@@ -203,7 +203,7 @@ class UserControllerTest extends TestCase
             'nickname' => $newNickname,
         ]);
 
-        dump($response->content());
+        //dump($response->content());
     
         $response->assertStatus(200)
             ->assertJson([
@@ -215,7 +215,29 @@ class UserControllerTest extends TestCase
             'nickname' => 'Anonymous',
         ]);
         
+    }
 
+    //Logout
+    public function test_logout_is_correct(): void
+    {
+        
+            $user = User::factory()->create([
+                'nickname' => 'OldNickname',
+                'email' => 'old@example.com',
+                'password' => '123456789',
+                'role_id' => Role::where('name', 'player')->first(),
+            ]);
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $user->createToken('player_token', ['player'])->accessToken,
+            ])->getJson('/api/logout');
+
+            dump($response->content());
+
+            $response->assertStatus(200)
+            ->assertJson([
+                'message' => 'Successfully logged out. See you soon!'
+            ]);
+        
     }
 
 

--- a/tests/Feature/UserControllerTest.php
+++ b/tests/Feature/UserControllerTest.php
@@ -1,6 +1,10 @@
 <?php
 
 namespace Tests\Feature;
+
+Use App\Models\Game;
+use App\Models\User;
+use App\Models\Role;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Laravel\Passport\Passport;
 use Illuminate\Foundation\Testing\WithFaker;
@@ -22,5 +26,102 @@ class UserControllerTest extends TestCase
         ]);    
 
         $response->assertStatus(201);
+    }
+
+    public function test_register_nickname_not_valid(): void
+    {
+        $response = $this->postJson('/api/register',[
+            'nickname' => '/*-+=`',
+            'email' => 'test@example.com',
+            'password' => 'testing123'
+
+        ]);    
+
+        $response->assertJson(['message' => 'Invalid request']);
+        
+    }
+
+    public function test_register_empty_nickname(): void
+    {
+        $response = $this->postJson('/api/register',[
+            'nickname' => '',
+            'email' => 'test@example.com',
+            'password' => 'testing123'
+
+        ]);    
+
+        $response->assertStatus(201);
+
+    }
+
+    public function test_register_data_is_saved(): void
+    {
+        $response = $this->postJson('/api/register',[
+            'nickname' => '',
+            'email' => 'test@example.es',
+            'password' => 'testing123'
+
+        ]);    
+
+        $response->assertStatus(201);
+        $this->assertDatabaseMissing('users', [
+            'email' => 'test@example.com' ]);
+    }
+    public function test_register_email_already_exist(): void
+    {
+        $response = $this->post('/api/register',[
+            'nickname' => 'Mia',
+            'email' => 'test@example.es',
+            'password' => 'testing123'
+
+        ]);    
+
+        $response->assertStatus(422);
+        $this->assertDatabaseMissing('users', [
+            'email' => 'test@example.es' ]);
+    }
+
+    //LOGIN
+    public function test_login_is_correct(): void
+    {
+        $response = $this->postJson('/api/register',[
+            'nickname' => 'Testnickname',
+            'email' => 'test@example.com',
+            'password' => 'testing123',
+
+        ]);    
+
+        $response->assertStatus(201);
+    }
+
+    public function test_login_invalid_password(): void
+    {
+        $response = $this->postJson('/api/register',[
+            'nickname' => 'Testnickname',
+            'email' => 'test@example.com',
+            'password' => '12345',
+
+        ]);    
+
+        $response->assertJson(['message' => 'Invalid request']);
+    }
+
+    public function test_login_as_player()
+    {
+        $player = User::create([
+            'email' => 'player36@example.com',
+            'password' => '123456789',
+            'role_id' => Role::where('name', 'player')->first()->id,
+        ]);
+
+        $response = $this->postJson('/api/login', [
+            'email' => 'player36@example.com',
+            'password' => '123456789',
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('users', [
+            'role_id' => '2' ]);
+        
     }
 }


### PR DESCRIPTION
## Testing
- Using Postman
- Using Php Unit

**Php Unit**

- Creation of tests using artisan command.
```
php artisan make:test UserControllerTest
php artisan make:test UserControllerActionsTest
php artisan make:test GameController
```
- Using of 'Database Transaction to enable automatic database transaction. Laravel provides this trait to facilitate database administration during testing and to ensure that testing does not affect the production database.
```
Use App\Models\Game;
use App\Models\User;
use App\Models\Role;
use Illuminate\Foundation\Testing\DatabaseTransactions;
```

```
class UserControllerTest extends TestCase
{ 
    use DatabaseTransactions;
```
- User Controller Test:
	- test_register_is_correct
	- test_register_empty_nickname
	- test_register_data_is_saved
	- test_register_email_already_exist
	- test_login_is_correct
	- test_login_invalid_password
	- test_login_as_player
	- test_user_can_update_nickname
	- test_user_admin_cannot_update_nickname
	- test_user_player_can_update_with_empty_nickname_
	- test_logout_is_correct
- User Controller Actions Test
	- test_admin_can_list_players
	- test_player_cannot_list_players
	- test_admin_can_list_ranking
	- test_player_cannot_ranking_players
	- test_admin_can_see_winner
	- test_admin_cannot_see_winner_with_role_player_and_token_admin
	- test_admin_can_see_one_loser
	- test_player_cannot_see_loser_list
- Game Controller Test
	- test_games_player_can_roll_dice
	- test_games_player1_cannot_play_in_roll_dice_of_player2
	- test_games_player_can_see_its_rolls
	- test_games_admin_cannot_see_players_rolls_list
	- test_games_delete_rolls_works
	- test_games_admin_cannot_delete_players_rolls

- Updates of functions:
	- update nickname
	- logout
	- extra validations (adding to check if the request user id is the same of the route id)